### PR TITLE
Note QUERY_STRING support on vod.cgi

### DIFF
--- a/HTTPGET_URLs
+++ b/HTTPGET_URLs
@@ -16,6 +16,8 @@ http://10.99.77.1/Config/config.ini
 
 # Video file listing (filename format n:{URL},s:1000000 - need to work out what this means!)
 http://10.99.77.1/blackvue_vod.cgi
+http://10.99.77.1/blackvue_vod.cgi?path=d:/Record/ # the default
+http://10.99.77.1/blackvue_vod.cgi?path=d:/        # see what else exists, only directories and .mp4 files 
 
 # Video and metadata file for download via HTTP
 # (note .thm file doesn't seem to do anything; have yet to find GPS/G-force data)


### PR DESCRIPTION
Decompiling blackvue_vod.cgi let me see that it would take
a query string and path to look in.  Unfortunately it filters out
files that aren't .mp4.

https://retdec.com/decompilation-run/

It also showed that the s:1000000 appears to be a hardcoded value with unknown meaning.
